### PR TITLE
Fix for #4 (tag/value separator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ starts the broadcast mode immediatly after all tabs are created
 `i2cssh -b foo1.bar foo2.bar foo3.bar`
 
 ### -t --tags
-ec2 tag in the format of $NAME_$VALUE (underscore separated as it is forbidden to be used in tags)
-`i2cssh -t env_staging -t end_dev`
-optionaly: you can run
+ec2 tag in the format of $NAME=$VALUE (the `=` separator can be overridden in .i2csshrc -- see i2csshrc.example.yml).
+`i2cssh -t env=staging -t end=dev`
+Optionally: you can run
 `i2cssh -t`
 to get asked to which tag you want to connect to. Downside: you can only choose one key-value pair.
 
@@ -65,7 +65,7 @@ I recommend using [envchain](https://github.com/sorah/envchain) and creating som
  * -m, --machines a,b,c             Comma-separated list of hosts
  * -f, --file FILE                  Cluster file (one hostname per line)
  * -A, --forward-agent              Enable SSH agent forwarding
- * -l, --login LOGIN                SSH login name
+ * DONE (-u, --user) ~~-l, --login LOGIN                SSH login name~~
  * -e, --environment KEY=VAL        Send environment vars (comma-separated list, need to start with LC_)
  * -r, --rank                       Send LC_RANK with the host number as environment variable
  * -F, --fullscreen                 Make the window fullscreen

--- a/i2csshrc.example.yml
+++ b/i2csshrc.example.yml
@@ -2,6 +2,7 @@
 aws:
   region: eu-central-1            # the aws region to doi calls to
   usePrivateDns: false            # whether to use private dns names
+  nameValSeparator: ":"           # tag name/value separator (overrides default "=")
   only:                           # only check the following tag key's
     - Name
     - Purpose

--- a/lib/parse-tags.js
+++ b/lib/parse-tags.js
@@ -9,10 +9,10 @@ module.exports = function(tags, config) {
   }
   var filters = []
   if (typeof tags == "string") {
-    filters.push(getFilter(tags))
+    filters.push(getFilter(tags, config))
   } else {
     _.each(tags, function(tag) {
-      filters.push(getFilter(tag))
+      filters.push(getFilter(tag, config))
     })
   }
   return new Promise(function(resolve, reject) {
@@ -42,8 +42,9 @@ module.exports = function(tags, config) {
   });
 }
 
-function getFilter(tagString) {
-  var splitted = tagString.split('_')
+function getFilter(tagString, config) {
+  var sep = config.aws.nameValSeparator ? config.aws.nameValSeparator : "="
+  var splitted = tagString.split(sep)
   var tagKey = splitted[0]
   var tagValue = splitted[1]
   var values = {}


### PR DESCRIPTION
Here's a proposed fix.  This changes the default separator from `_` to `=`, as this seems much less likely to need to be overridden.  However, anyone with aliases currently using `_` would need to modify them.  If that's something you'd rather not do, I could revert back to `_` by default and leave the other changes.